### PR TITLE
Make default module mapping logic consistent and easy to understand

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -189,14 +189,10 @@ DEFAULT_MODULE_MAPPING: Dict[str, Tuple[str, ...]] = {
 }
 
 DEFAULT_TYPE_STUB_MODULE_PATTERN_MAPPING: Dict[re.Pattern, List[Callable[[Match[str]], str]]] = {
-    re.compile(r"""^stubs_(.+)"""): [first_group_hyphen_to_underscore],
-    re.compile(r"""^types_(.+)"""): [first_group_hyphen_to_underscore],
-    re.compile(r"""^stubs-(.+)"""): [first_group_hyphen_to_underscore],
-    re.compile(r"""^types-(.+)"""): [first_group_hyphen_to_underscore],
-    re.compile(r"""^(.+)_stubs"""): [first_group_hyphen_to_underscore],
-    re.compile(r"""^(.+)_types"""): [first_group_hyphen_to_underscore],
-    re.compile(r"""^(.+)-stubs"""): [first_group_hyphen_to_underscore],
-    re.compile(r"""^(.+)-types"""): [first_group_hyphen_to_underscore],
+    re.compile(r"""^stubs[_-](.+)"""): [first_group_hyphen_to_underscore],
+    re.compile(r"""^types[_-](.+)"""): [first_group_hyphen_to_underscore],
+    re.compile(r"""^(.+)[_-]stubs"""): [first_group_hyphen_to_underscore],
+    re.compile(r"""^(.+)[_-]types"""): [first_group_hyphen_to_underscore],
 }
 
 DEFAULT_TYPE_STUB_MODULE_MAPPING: Dict[str, Tuple[str, ...]] = {

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -100,7 +100,6 @@ DEFAULT_MODULE_PATTERN_MAPPING: Dict[re.Pattern, List[Callable[[Match[str]], str
     ],
     re.compile(r"""^oslo-.+"""): [all_hyphen_to_underscore],
     re.compile(r"""^python-(.+)"""): [first_group_hyphen_to_underscore],
-    re.compile(r"""^python-(.+)"""): [first_group_hyphen_to_underscore],
 }
 
 DEFAULT_MODULE_MAPPING: Dict[str, Tuple[str, ...]] = {

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -384,10 +384,11 @@ async def map_third_party_modules_to_addresses(
             elif proj_name in DEFAULT_TYPE_STUB_MODULE_MAPPING:
                 modules_to_add = DEFAULT_TYPE_STUB_MODULE_MAPPING[proj_name]
                 is_type_stub = True
-            elif modules_to_add := generate_mappings_from_pattern(proj_name, is_type_stub=False):
-                is_type_stub = False
+            # check for stubs first, since stub packages may also match impl package patterns
             elif modules_to_add := generate_mappings_from_pattern(proj_name, is_type_stub=True):
                 is_type_stub = True
+            elif modules_to_add := generate_mappings_from_pattern(proj_name, is_type_stub=False):
+                is_type_stub = False
             else:
                 modules_to_add = (fallback_value,)
                 is_type_stub = False

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -20,6 +20,7 @@ from pants.backend.python.dependency_inference.default_module_mapping import (
     DEFAULT_MODULE_MAPPING,
     DEFAULT_MODULE_PATTERN_MAPPING,
     DEFAULT_TYPE_STUB_MODULE_MAPPING,
+    DEFAULT_TYPE_STUB_MODULE_PATTERN_MAPPING,
 )
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
@@ -233,7 +234,10 @@ class FirstPartyPythonTargetsMappingMarker(FirstPartyPythonMappingImplMarker):
     pass
 
 
-@rule(desc="Creating map of first party Python targets to Python modules", level=LogLevel.DEBUG)
+@rule(
+    desc="Creating map of first party Python targets to Python modules",
+    level=LogLevel.DEBUG,
+)
 async def map_first_party_python_targets_to_modules(
     _: FirstPartyPythonTargetsMappingMarker,
     all_python_targets: AllPythonTargets,
@@ -312,35 +316,25 @@ class ThirdPartyPythonModuleMapping:
 
 
 @functools.cache
-def generate_mappings_from_pattern(proj_name: str) -> Iterable[str]:
-    """Generate an iterable of possible module mappings from a project name using a regex pattern.
+def generate_mappings_from_pattern(proj_name: str, is_type_stub: bool) -> Tuple[str, ...]:
+    """Generate a tuple of possible module mappings from a project name using a regex pattern.
 
     e.g. google-cloud-foo -> [google.cloud.foo, google.cloud.foo_v1, google.cloud.foo_v2]
     Should eliminate the need to "manually" add a mapping for every service
     proj_name: The project name to generate mappings for e.g google-cloud-datastream
     """
+    pattern_mappings = (
+        DEFAULT_TYPE_STUB_MODULE_PATTERN_MAPPING if is_type_stub else DEFAULT_MODULE_PATTERN_MAPPING
+    )
     pattern_values = []
-    for match_pattern, replace_patterns in DEFAULT_MODULE_PATTERN_MAPPING.items():
+    for match_pattern, replace_patterns in pattern_mappings.items():
         if match_pattern.match(proj_name) is not None:
             pattern_values = [
                 match_pattern.sub(replace_pattern, proj_name)
                 for replace_pattern in replace_patterns
             ]
             break  # stop after the first match in the rare chance that there are multiple matches
-    return pattern_values
-
-
-@functools.cache
-def generate_mappings(proj_name: str, fallback_value: str) -> Iterable[str]:
-    """Will try the default mapping first and if no mapping is found, try the pattern match.
-
-    If those fail, use the fallback_value
-    """
-    return (
-        DEFAULT_MODULE_MAPPING.get(proj_name)
-        or generate_mappings_from_pattern(proj_name)
-        or (fallback_value,)
-    )
+    return tuple(pattern_values)
 
 
 @rule(desc="Creating map of third party targets to Python modules", level=LogLevel.DEBUG)
@@ -355,23 +349,23 @@ async def map_third_party_modules_to_addresses(
     for tgt in all_python_targets.third_party:
         resolve = tgt[PythonRequirementResolveField].normalized_value(python_setup)
 
-        def add_modules(modules: Iterable[str], *, type_stub: bool = False) -> None:
+        def add_modules(modules: Iterable[str], *, is_type_stub: bool) -> None:
             for module in modules:
                 resolves_to_modules_to_providers[resolve][module].append(
                     ModuleProvider(
                         tgt.address,
-                        ModuleProviderType.TYPE_STUB if type_stub else ModuleProviderType.IMPL,
+                        ModuleProviderType.TYPE_STUB if is_type_stub else ModuleProviderType.IMPL,
                     )
                 )
 
         explicit_modules = tgt.get(PythonRequirementModulesField).value
         if explicit_modules:
-            add_modules(explicit_modules)
+            add_modules(explicit_modules, is_type_stub=False)
             continue
 
         explicit_stub_modules = tgt.get(PythonRequirementTypeStubModulesField).value
         if explicit_stub_modules:
-            add_modules(explicit_stub_modules, type_stub=True)
+            add_modules(explicit_stub_modules, is_type_stub=True)
             continue
 
         # Else, fall back to defaults.
@@ -382,21 +376,23 @@ async def map_third_party_modules_to_addresses(
             proj_name = canonicalize_project_name(req.project_name)
             fallback_value = req.project_name.strip().lower().replace("-", "_")
 
-            in_stubs_map = proj_name in DEFAULT_TYPE_STUB_MODULE_MAPPING
-            starts_with_prefix = fallback_value.startswith(("types_", "stubs_"))
-            ends_with_prefix = fallback_value.endswith(("_types", "_stubs"))
-            if proj_name not in DEFAULT_MODULE_MAPPING and (
-                in_stubs_map or starts_with_prefix or ends_with_prefix
-            ):
-                if in_stubs_map:
-                    stub_modules = DEFAULT_TYPE_STUB_MODULE_MAPPING[proj_name]
-                else:
-                    stub_modules = (
-                        fallback_value[6:] if starts_with_prefix else fallback_value[:-6],
-                    )
-                add_modules(stub_modules, type_stub=True)
+            modules_to_add: Tuple[str, ...]
+            is_type_stub: bool
+            if proj_name in DEFAULT_MODULE_MAPPING:
+                modules_to_add = DEFAULT_MODULE_MAPPING[proj_name]
+                is_type_stub = False
+            elif proj_name in DEFAULT_TYPE_STUB_MODULE_MAPPING:
+                modules_to_add = DEFAULT_TYPE_STUB_MODULE_MAPPING[proj_name]
+                is_type_stub = True
+            elif modules_to_add := generate_mappings_from_pattern(proj_name, is_type_stub=False):
+                is_type_stub = False
+            elif modules_to_add := generate_mappings_from_pattern(proj_name, is_type_stub=True):
+                is_type_stub = True
             else:
-                add_modules(generate_mappings(proj_name, fallback_value))
+                modules_to_add = (fallback_value,)
+                is_type_stub = False
+
+            add_modules(modules_to_add, is_type_stub=is_type_stub)
 
     return ThirdPartyPythonModuleMapping(
         FrozenDict(

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -985,6 +985,42 @@ def test_generate_mappings_from_pattern_matches_para(
     assert generate_mappings_from_pattern(proj_name, is_type_stub=False) == expected_modules
 
 
+@pytest.mark.parametrize(
+    ("proj_name", "expected_modules"),
+    [
+        (
+            "types-requests",
+            ("requests",),
+        ),
+        (
+            "botocore-stubs",
+            ("botocore",),
+        ),
+        (
+            "django-types",
+            ("django",),
+        ),
+        (
+            "types_requests",
+            ("requests",),
+        ),
+        (
+            "botocore_stubs",
+            ("botocore",),
+        ),
+        (
+            "django_types",
+            ("django",),
+        ),
+        ("", tuple()),
+    ],
+)
+def test_generate_type_stub_mappings_from_pattern_matches_para(
+    proj_name: str, expected_modules: Tuple[str]
+) -> None:
+    assert generate_mappings_from_pattern(proj_name, is_type_stub=True) == expected_modules
+
+
 def test_number_of_capture_groups_for_functions() -> None:
     with pytest.raises(ValueError):
         re.sub("foo", first_group_hyphen_to_underscore, "foo")

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -7,7 +7,7 @@ import re
 from pathlib import PurePath
 from textwrap import dedent
 from types import FunctionType
-from typing import Iterable
+from typing import Iterable, Tuple
 
 import pytest
 from packaging.utils import canonicalize_name as canonicalize_project_name
@@ -23,6 +23,7 @@ from pants.backend.python.dependency_inference.default_module_mapping import (
     DEFAULT_MODULE_MAPPING,
     DEFAULT_MODULE_PATTERN_MAPPING,
     DEFAULT_TYPE_STUB_MODULE_MAPPING,
+    DEFAULT_TYPE_STUB_MODULE_PATTERN_MAPPING,
     first_group_hyphen_to_underscore,
     two_groups_hyphens_two_replacements_with_suffix,
 )
@@ -61,13 +62,19 @@ def test_default_module_mapping_is_normalized() -> None:
 
 
 def test_default_module_mapping_uses_tuples() -> None:
-    for modules in DEFAULT_MODULE_MAPPING.values():
+    for modules in [
+        *DEFAULT_MODULE_MAPPING.values(),
+        *DEFAULT_TYPE_STUB_MODULE_MAPPING.values(),
+    ]:
         assert isinstance(modules, tuple)
         assert len(modules) > 0
 
 
 def test_default_module_pattern_mapping_keys_and_value_types() -> None:
-    for pattern, replacements in DEFAULT_MODULE_PATTERN_MAPPING.items():
+    for pattern, replacements in [
+        *DEFAULT_MODULE_PATTERN_MAPPING.items(),
+        *DEFAULT_TYPE_STUB_MODULE_PATTERN_MAPPING.items(),
+    ]:
         assert isinstance(pattern, re.Pattern)
         assert isinstance(replacements, Iterable)
         for replacement in replacements:
@@ -98,13 +105,16 @@ def test_first_party_modules_mapping() -> None:
         Address("", relative_file_path="root.py"), ModuleProviderType.IMPL
     )
     util_provider = ModuleProvider(
-        Address("src/python/util", relative_file_path="strutil.py"), ModuleProviderType.IMPL
+        Address("src/python/util", relative_file_path="strutil.py"),
+        ModuleProviderType.IMPL,
     )
     util_stubs_provider = ModuleProvider(
-        Address("src/python/util", relative_file_path="strutil.pyi"), ModuleProviderType.TYPE_STUB
+        Address("src/python/util", relative_file_path="strutil.pyi"),
+        ModuleProviderType.TYPE_STUB,
     )
     test_provider = ModuleProvider(
-        Address("tests/python/project_test", relative_file_path="test.py"), ModuleProviderType.IMPL
+        Address("tests/python/project_test", relative_file_path="test.py"),
+        ModuleProviderType.IMPL,
     )
     mapping = FirstPartyPythonModuleMapping(
         FrozenDict(
@@ -125,7 +135,10 @@ def test_first_party_modules_mapping() -> None:
     )
 
     def assert_addresses(
-        mod: str, expected: tuple[PossibleModuleProvider, ...], *, resolve: str | None = None
+        mod: str,
+        expected: tuple[PossibleModuleProvider, ...],
+        *,
+        resolve: str | None = None,
     ) -> None:
         assert mapping.providers_for_module(mod, resolve=resolve) == expected
 
@@ -196,7 +209,10 @@ def test_third_party_modules_mapping() -> None:
     )
 
     def assert_addresses(
-        mod: str, expected: tuple[PossibleModuleProvider, ...], *, resolve: str | None = None
+        mod: str,
+        expected: tuple[PossibleModuleProvider, ...],
+        *,
+        resolve: str | None = None,
     ) -> None:
         assert mapping.providers_for_module(mod, resolve) == expected
 
@@ -307,13 +323,19 @@ def test_map_first_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
                     {
                         "project.util.dirutil": (
                             ModuleProvider(
-                                Address("src/python/project/util", relative_file_path="dirutil.py"),
+                                Address(
+                                    "src/python/project/util",
+                                    relative_file_path="dirutil.py",
+                                ),
                                 ModuleProviderType.IMPL,
                             ),
                         ),
                         "project.util.tarutil": (
                             ModuleProvider(
-                                Address("src/python/project/util", relative_file_path="tarutil.py"),
+                                Address(
+                                    "src/python/project/util",
+                                    relative_file_path="tarutil.py",
+                                ),
                                 ModuleProviderType.IMPL,
                             ),
                         ),
@@ -323,15 +345,24 @@ def test_map_first_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
                     {
                         "multiple_owners": (
                             ModuleProvider(
-                                Address("build-support", relative_file_path="multiple_owners.py"),
+                                Address(
+                                    "build-support",
+                                    relative_file_path="multiple_owners.py",
+                                ),
                                 ModuleProviderType.IMPL,
                             ),
                             ModuleProvider(
-                                Address("src/python", relative_file_path="multiple_owners.py"),
+                                Address(
+                                    "src/python",
+                                    relative_file_path="multiple_owners.py",
+                                ),
                                 ModuleProviderType.IMPL,
                             ),
                             ModuleProvider(
-                                Address("src/python", relative_file_path="multiple_owners.pyi"),
+                                Address(
+                                    "src/python",
+                                    relative_file_path="multiple_owners.pyi",
+                                ),
                                 ModuleProviderType.TYPE_STUB,
                             ),
                         ),
@@ -411,13 +442,20 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
             req("multiple_owners2", "multiple_owners==2", resolve="another"),
             req("multiple_owners_types", "types-multiple_owners==1", resolve="another"),
             # Only assume it's a type stubs dep if we are certain it's not an implementation.
-            req("looks_like_stubs", "looks-like-stubs-types", modules=["looks_like_stubs"]),
+            req(
+                "looks_like_stubs",
+                "looks-like-stubs-types",
+                modules=["looks_like_stubs"],
+            ),
             req("google-cloud-hardyhar", "google-cloud-hardyhar"),
             req("google-cloud-secret-manager", "google-cloud-secret-manager"),
             req("azure-keyvault-secrets", "azure-keyvault-secrets"),
             req("django-model-utils", "model_utils"),
             req("django-taggit", "taggit"),
-            req("opentelemetry-instrumentation-botocore", "opentelemetry-instrumentation-botocore"),
+            req(
+                "opentelemetry-instrumentation-botocore",
+                "opentelemetry-instrumentation-botocore",
+            ),
         ]
     )
     rule_runner.write_files({"BUILD": build_file})
@@ -432,7 +470,8 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
                     {
                         "multiple_owners": (
                             ModuleProvider(
-                                Address("", target_name="multiple_owners2"), ModuleProviderType.IMPL
+                                Address("", target_name="multiple_owners2"),
+                                ModuleProviderType.IMPL,
                             ),
                             ModuleProvider(
                                 Address("", target_name="multiple_owners_types"),
@@ -451,7 +490,8 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
                         ),
                         "file_dist": (
                             ModuleProvider(
-                                Address("", target_name="file_dist"), ModuleProviderType.IMPL
+                                Address("", target_name="file_dist"),
+                                ModuleProviderType.IMPL,
                             ),
                         ),
                         "google.cloud.hardyhar": (
@@ -504,12 +544,14 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
                         ),
                         "looks_like_stubs": (
                             ModuleProvider(
-                                Address("", target_name="looks_like_stubs"), ModuleProviderType.IMPL
+                                Address("", target_name="looks_like_stubs"),
+                                ModuleProviderType.IMPL,
                             ),
                         ),
                         "mapped_module": (
                             ModuleProvider(
-                                Address("", target_name="modules"), ModuleProviderType.IMPL
+                                Address("", target_name="modules"),
+                                ModuleProviderType.IMPL,
                             ),
                         ),
                         "model_utils": (
@@ -520,12 +562,16 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
                         ),
                         "multiple_owners": (
                             ModuleProvider(
-                                Address("", target_name="multiple_owners1"), ModuleProviderType.IMPL
+                                Address("", target_name="multiple_owners1"),
+                                ModuleProviderType.IMPL,
                             ),
                         ),
                         "opentelemetry.instrumentation.botocore": (
                             ModuleProvider(
-                                Address("", target_name="opentelemetry-instrumentation-botocore"),
+                                Address(
+                                    "",
+                                    target_name="opentelemetry-instrumentation-botocore",
+                                ),
                                 ModuleProviderType.IMPL,
                             ),
                         ),
@@ -542,37 +588,44 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
                         ),
                         "typed_dep1": (
                             ModuleProvider(
-                                Address("", target_name="typed-dep1"), ModuleProviderType.TYPE_STUB
+                                Address("", target_name="typed-dep1"),
+                                ModuleProviderType.TYPE_STUB,
                             ),
                         ),
                         "typed_dep2": (
                             ModuleProvider(
-                                Address("", target_name="typed-dep2"), ModuleProviderType.TYPE_STUB
+                                Address("", target_name="typed-dep2"),
+                                ModuleProviderType.TYPE_STUB,
                             ),
                         ),
                         "typed_dep3": (
                             ModuleProvider(
-                                Address("", target_name="typed-dep3"), ModuleProviderType.TYPE_STUB
+                                Address("", target_name="typed-dep3"),
+                                ModuleProviderType.TYPE_STUB,
                             ),
                         ),
                         "typed_dep4": (
                             ModuleProvider(
-                                Address("", target_name="typed-dep4"), ModuleProviderType.TYPE_STUB
+                                Address("", target_name="typed-dep4"),
+                                ModuleProviderType.TYPE_STUB,
                             ),
                         ),
                         "typed_dep5": (
                             ModuleProvider(
-                                Address("", target_name="typed-dep5"), ModuleProviderType.TYPE_STUB
+                                Address("", target_name="typed-dep5"),
+                                ModuleProviderType.TYPE_STUB,
                             ),
                         ),
                         "un_normalized_project": (
                             ModuleProvider(
-                                Address("", target_name="un_normalized"), ModuleProviderType.IMPL
+                                Address("", target_name="un_normalized"),
+                                ModuleProviderType.IMPL,
                             ),
                         ),
                         "vcs_dist": (
                             ModuleProvider(
-                                Address("", target_name="vcs_dist"), ModuleProviderType.IMPL
+                                Address("", target_name="vcs_dist"),
+                                ModuleProviderType.IMPL,
                             ),
                         ),
                     }
@@ -580,17 +633,18 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
             }
         )
     )
-    print(result)
-    print(expected)
     assert result == expected
 
 
 def test_map_module_to_address(rule_runner: RuleRunner) -> None:
     def assert_owners(
-        module: str, expected: list[Address], expected_ambiguous: list[Address] | None = None
+        module: str,
+        expected: list[Address],
+        expected_ambiguous: list[Address] | None = None,
     ) -> None:
         owners = rule_runner.request(
-            PythonModuleOwners, [PythonModuleOwnersRequest(module, resolve="python-default")]
+            PythonModuleOwners,
+            [PythonModuleOwnersRequest(module, resolve="python-default")],
         )
         assert list(owners.unambiguous) == expected
         assert list(owners.ambiguous) == (expected_ambiguous or [])
@@ -698,7 +752,10 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
     assert_owners("valid_dep", [Address("", target_name="valid_dep")])
     assert_owners(
         "dep_w_stub",
-        [Address("", target_name="dep_w_stub"), Address("", target_name="dep_w_stub-types")],
+        [
+            Address("", target_name="dep_w_stub"),
+            Address("", target_name="dep_w_stub-types"),
+        ],
     )
     assert_owners("script", [Address("", target_name="script")])
     assert_owners("no_stub.app", expected=[Address("root/no_stub", relative_file_path="app.py")])
@@ -710,7 +767,8 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
         ],
     )
     assert_owners(
-        "package.subdir", [Address("root/package/subdir", relative_file_path="__init__.py")]
+        "package.subdir",
+        [Address("root/package/subdir", relative_file_path="__init__.py")],
     )
     assert_owners(
         "dep_with_stub",
@@ -788,7 +846,8 @@ def test_resolving_ambiguity_by_filesystem_proximity(rule_runner: RuleRunner) ->
     )
 
     owners = rule_runner.request(
-        PythonModuleOwners, [PythonModuleOwnersRequest("aa.bb.foo", None, locality=None)]
+        PythonModuleOwners,
+        [PythonModuleOwnersRequest("aa.bb.foo", None, locality=None)],
     )
     assert list(owners.unambiguous) == []
     assert list(owners.ambiguous) == [
@@ -797,19 +856,22 @@ def test_resolving_ambiguity_by_filesystem_proximity(rule_runner: RuleRunner) ->
     ]
 
     owners = rule_runner.request(
-        PythonModuleOwners, [PythonModuleOwnersRequest("aa.bb.foo", None, locality="root1/")]
+        PythonModuleOwners,
+        [PythonModuleOwnersRequest("aa.bb.foo", None, locality="root1/")],
     )
     assert list(owners.unambiguous) == [Address("root1/aa/bb", relative_file_path="foo.py")]
     assert list(owners.ambiguous) == []
 
     owners = rule_runner.request(
-        PythonModuleOwners, [PythonModuleOwnersRequest("aa.bb.foo", None, locality="root2/")]
+        PythonModuleOwners,
+        [PythonModuleOwnersRequest("aa.bb.foo", None, locality="root2/")],
     )
     assert list(owners.unambiguous) == [Address("root2/aa/bb", relative_file_path="foo.py")]
     assert list(owners.ambiguous) == []
 
     owners = rule_runner.request(
-        PythonModuleOwners, [PythonModuleOwnersRequest("aa.bb.foo", None, locality="root3/")]
+        PythonModuleOwners,
+        [PythonModuleOwnersRequest("aa.bb.foo", None, locality="root3/")],
     )
     assert list(owners.unambiguous) == []
     assert list(owners.ambiguous) == [
@@ -871,7 +933,8 @@ def test_issue_15111(rule_runner: RuleRunner) -> None:
                         "docopt": (
                             ModuleProvider(Address("", target_name="req"), ModuleProviderType.IMPL),
                             ModuleProvider(
-                                Address("", target_name="req"), ModuleProviderType.TYPE_STUB
+                                Address("", target_name="req"),
+                                ModuleProviderType.TYPE_STUB,
                             ),
                         ),
                     }
@@ -886,41 +949,40 @@ def test_issue_15111(rule_runner: RuleRunner) -> None:
     [
         (
             "google-cloud-hardyhar",
-            [
+            (
                 "google.cloud.hardyhar",
                 "google.cloud.hardyhar_v1",
                 "google.cloud.hardyhar_v2",
                 "google.cloud.hardyhar_v3",
-            ],
+            ),
         ),
         (
             "python-jose",
-            ["jose"],
+            ("jose",),
         ),
-        ("opentelemetry-instrumentation-tornado", ["opentelemetry.instrumentation.tornado"]),
-        ("azure-mgmt-consumption", ["azure.mgmt.consumption"]),
-        ("azure-keyvault", ["azure.keyvault"]),
+        (
+            "opentelemetry-instrumentation-tornado",
+            ("opentelemetry.instrumentation.tornado",),
+        ),
+        ("azure-mgmt-consumption", ("azure.mgmt.consumption",)),
+        ("azure-keyvault", ("azure.keyvault",)),
         (
             "django-admin-cursor-paginator",
-            [
-                "admin_cursor_paginator",
-            ],
+            ("admin_cursor_paginator",),
         ),
         (
             "django-dotenv",
-            [
-                "dotenv",
-            ],
+            ("dotenv",),
         ),
-        ("oslo-service", ["oslo_service"]),
-        ("pyopenssl", []),
-        ("", []),
+        ("oslo-service", ("oslo_service",)),
+        ("pyopenssl", tuple()),
+        ("", tuple()),
     ],
 )
 def test_generate_mappings_from_pattern_matches_para(
-    proj_name: str, expected_modules: list[str]
+    proj_name: str, expected_modules: Tuple[str]
 ) -> None:
-    assert generate_mappings_from_pattern(proj_name) == expected_modules
+    assert generate_mappings_from_pattern(proj_name, is_type_stub=False) == expected_modules
 
 
 def test_number_of_capture_groups_for_functions() -> None:


### PR DESCRIPTION
- Use Python subsystem's default ICs when generating builtin lockfile (#20500)
- Update built-in ruff 0.1.6 -> 0.2.1 (#20499)
- add module mapping overrides for some django-* modules (#20504)
- Allow using Ruff to format BUILD files (#20411)
- Allow unmatching "changed" globs  (#20505)
- plumb through Pex's --check zipapp validation (#20481)
- upgrade known terraform versions (#20469)
- Handle unresolved ambiguous entrypoint dependency for PEX as unowned dependency (#20390)
- Improve build file syntax error (#20493)
- python: improve error message when parsing Python interpreter constraints (#20297)
- make default module mapping logic consistent and easy to understand
- added more default modules
